### PR TITLE
feat: add QR code endpoint for room sharing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,102 +1,110 @@
-# Bingo App Backend — v2 Refactor
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## Project Overview
+
 Bingo room management API with real-time number drawing via WebSocket.
-Spring Boot + PostgreSQL, layered architecture (controller/service/repository).
+Rooms are created via REST, numbers are drawn and broadcast in real-time over STOMP WebSocket.
 
 ## Stack
-- **Java 21**, **Spring Boot 3.4.x** (latest stable)
-- **Maven**, **Lombok**, **PostgreSQL**
+
+- **Java 21**, **Spring Boot 3.4.4**, **Maven**
+- **Lombok**, **PostgreSQL** (prod), **H2** (dev/test)
 - **WebSocket (STOMP)** for real-time number broadcasting
-- **SpringDoc OpenAPI** for API docs
-- **JUnit 5 + Mockito** for unit tests, **RestAssured** for integration tests
-- **JaCoCo** for coverage (minimum 80%)
-- **Docker Compose** for local dev
+- **SpringDoc OpenAPI** for API docs (Swagger UI at `/swagger-ui.html`)
+- **JUnit 5 + Mockito** (unit), **RestAssured** (integration), **JaCoCo** (80% min coverage)
+
+## Build & Test Commands
+
+```bash
+mvn clean compile              # Compile
+mvn clean test                 # Run all tests (unit + integration)
+mvn clean package              # Build JAR (includes tests)
+mvn spring-boot:run            # Run locally (dev profile, H2 in-memory)
+mvn test -Dtest=RoomServiceTest                    # Single test class
+mvn test -Dtest=RoomServiceTest#shouldCreateRoom   # Single test method
+```
+
+If `mvn` is not in PATH, install via SDKMAN (`sdk install maven`). Same for JDK 21.
+
+## Docker
+
+```bash
+docker-compose up                                    # Postgres only (dev)
+docker-compose -f docker-compose-app-bd.yml up       # App + Postgres
+```
 
 ## Architecture
-Layered: `controller → service → repository`
-- Controllers handle HTTP/WebSocket mapping and validation
-- Services contain business logic
-- Repositories handle persistence
-- Global exception handler via `@RestControllerAdvice`
-- Records for DTOs
-- Input validation with Bean Validation annotations
+
+Layered: `controller -> service -> repository`
+
+```
+com.yanajiki.application.bingoapp/
+  api/            # REST controllers, forms (CreateRoomForm), responses (RoomDTO, ApiResponse)
+  service/        # Business logic (RoomService) — all logic lives here
+  database/       # JPA entity (RoomEntity) + Spring Data repository
+  exception/      # Custom exceptions + GlobalExceptionHandler (@RestControllerAdvice)
+  websocket/      # STOMP WebSocket controller + config
+  config/         # CORS config, OpenAPI config
+  game/           # NumberLabelMapper interface + StandardBingoMapper (75-ball bingo rules)
+```
+
+### Key Design Decisions
+
+- **Controllers are thin** — they delegate everything to `RoomService`. No business logic in controllers.
+- **Game abstraction**: `NumberLabelMapper` interface defines valid number ranges and label format (B/I/N/G/O columns). `StandardBingoMapper` implements 75-ball bingo. This allows future variants (e.g., 90-ball).
+- **Drawn numbers** stored via `@ElementCollection` (separate `room_drawn_numbers` table), not CSV.
+- **Creator identity**: `creatorHash` (UUID) passed in `X-Creator-Hash` header for privileged operations (draw, delete). `sessionCode` (6-char alphanumeric via `SecureRandom`) is the public room identifier.
+- **Two DTO views**: `RoomDTO.fromEntityToCreator()` includes creatorHash; `RoomDTO.fromEntityToPlayer()` hides it via `@JsonInclude(NON_NULL)`.
+
+### API Endpoints
+
+| Method | Path | Description | Auth |
+|--------|------|-------------|------|
+| POST | `/api/v1/room` | Create room | None |
+| GET | `/api/v1/room/{session-code}` | Get room | `X-Creator-Hash` header (optional, determines view) |
+| DELETE | `/api/v1/room/{session-code}` | Delete room | `X-Creator-Hash` header (required) |
+| WS | `/bingo-connect` → `/app/add-number` | Draw number (broadcasts to `/room/{sessionCode}`) | creatorHash in payload |
+
+### Exception Handling
+
+Centralized in `GlobalExceptionHandler`:
+- `ConflictException` -> 409 (duplicate room name)
+- `RoomNotFoundException` -> 404
+- `MethodArgumentNotValidException` -> 400 (validation errors)
+- `IllegalArgumentException` -> 400 (business rule violation)
+- Generic `Exception` -> 500 (logged at ERROR)
+
+## Spring Profiles
+
+- **dev** (default): H2 in-memory, permissive CORS (`*`), H2 console at `/h2-console`
+- **prod**: PostgreSQL (env vars: `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`), strict CORS, `ddl-auto=validate`
+
+## Testing Patterns
+
+- **Unit tests** (`RoomServiceTest`): Mockito mocks for repository/mapper, `@Nested` + `@DisplayName` organization
+- **Integration tests** (`RoomControllerIntegrationTest`): RestAssured on random port with H2, BDD given/when/then style
+- **Entity tests** (`RoomEntityTest`): Factory method and append behavior
+- Tests use dev profile (H2) by default
+
+## Git Workflow
+
+- Branch `v2` for current development; merge to `main` when validated
+- Conventional commits format
+- Feature sub-branches off `v2` if needed
+
+## CI/CD
+
+GitHub Actions workflow triggered on PR to `develop` or `main`:
+1. Test (`mvn clean test` on JDK 21)
+2. Build artifact (`mvn clean package`)
+3. Docker build + push
 
 ## Team Structure (Standard)
 
-| Role | Model | Responsibility |
-|------|-------|---------------|
-| Orchestrator | Sonnet | Manages issues, delegates, reviews output, git workflow |
-| Implementer | Sonnet | Writes tests and implementation (TDD in single agent) |
-| Explorer | Haiku | Quick codebase searches and lookups |
-
-## Git Workflow
-- Branch: `v2` (all refactor work here)
-- Conventional commits
-- Feature sub-branches off `v2` if needed, otherwise commit directly to `v2`
-- Merge to `main` only after full refactor is validated
-
-## Refactor Issues
-
-### Issue 1: Upgrade pom.xml
-- Java 17 → 21
-- Spring Boot 3.2.3 → 3.4.x (latest stable)
-- Remove duplicate websocket dependency
-- Update commons-lang3 to latest
-- Add: springdoc-openapi, jacoco-maven-plugin, restassured, h2 (test scope)
-- Update Dockerfile to JDK 21
-
-### Issue 2: Introduce service layer
-- Create `RoomService` with all business logic extracted from controllers
-- Controllers become thin — delegate to service
-- WebSocketController delegates to service too
-
-### Issue 3: Global exception handler
-- Create `@RestControllerAdvice` class
-- Handle: ConflictException (409), RoomNotFoundException (404), MethodArgumentNotValidException (400), generic Exception (500)
-- Remove exception handlers from RoomController
-- Add `@ResponseStatus` to custom exceptions
-
-### Issue 4: Fix data model
-- Fix RoomRepository generic type (String → Long)
-- Replace drawnNumbers CSV string with `@ElementCollection` or JSON column
-- Use `SecureRandom` for session code generation
-- Remove dead password field
-- Validate drawn numbers (1-75 range, no duplicates)
-
-### Issue 5: Modernize DTOs and forms
-- Convert ApiResponse to record
-- Convert RoomDTO to record
-- Add Bean Validation to CreateRoomForm (@NotBlank, @Size, etc.)
-- Add Bean Validation to AddNumberForm
-- Move creatorHash from URL path to request header
-
-### Issue 6: Clean up code
-- Delete RoomMapper.java (dead code)
-- Replace System.out.println with SLF4J logger
-- Add Javadoc to all classes and public methods
-- Rename WebSocketController.greeting() to meaningful name
-
-### Issue 7: Spring profiles and configuration
-- Create application-dev.properties (H2)
-- Create application-prod.properties (PostgreSQL)
-- Clean up application.properties as base config
-- Tighten CORS (configurable origins per profile)
-- Add room TTL / expiration (optional)
-
-### Issue 8: Docker updates
-- Update Dockerfile to JDK 21
-- Pin PostgreSQL image version
-- Add volume persistence to dev docker-compose
-- Add health checks
-
-### Issue 9: Tests (TDD)
-- Unit tests for RoomService (Mockito)
-- Integration tests for RoomController (RestAssured)
-- WebSocket integration tests
-- Target: 80%+ coverage (JaCoCo)
-
-### Issue 10: API documentation
-- Add SpringDoc OpenAPI dependency
-- Annotate controllers with @Operation, @ApiResponse, @Tag
-- Swagger UI available at /swagger-ui.html
+| Role | Model | Tools & Skills | Responsibility |
+|------|-------|----------------|---------------|
+| Orchestrator | Sonnet | /new-feature, /status, gh CLI, TaskCreate/TaskUpdate | Manages issues, delegates, reviews output, git workflow |
+| Implementer | Sonnet | Read, Edit, Write, Grep, Glob, Bash, /review (self-review) | Writes tests and implementation (TDD in single agent). Follow conventions above |
+| Explorer | Haiku | Read, Glob, Grep | Quick codebase searches and lookups. No editing |

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,13 @@
 			<version>2.8.6</version>
 		</dependency>
 
+		<!-- QR Code generation -->
+		<dependency>
+			<groupId>com.google.zxing</groupId>
+			<artifactId>javase</artifactId>
+			<version>3.5.3</version>
+		</dependency>
+
 		<!-- Test -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/yanajiki/application/bingoapp/api/RoomController.java
+++ b/src/main/java/com/yanajiki/application/bingoapp/api/RoomController.java
@@ -3,6 +3,7 @@ package com.yanajiki.application.bingoapp.api;
 import com.yanajiki.application.bingoapp.api.form.CreateRoomForm;
 import com.yanajiki.application.bingoapp.api.response.ApiResponse;
 import com.yanajiki.application.bingoapp.api.response.RoomDTO;
+import com.yanajiki.application.bingoapp.service.QrCodeService;
 import com.yanajiki.application.bingoapp.service.RoomService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -13,6 +14,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -37,6 +40,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class RoomController {
 
 	private final RoomService roomService;
+	private final QrCodeService qrCodeService;
 
 	/**
 	 * Creates a new bingo room.
@@ -143,6 +147,44 @@ public class RoomController {
 		@Parameter(description = "Creator hash for authentication; must match the hash assigned at room creation", required = true)
 		@RequestHeader("X-Creator-Hash") String creatorHash) {
 		roomService.deleteRoom(sessionCode, creatorHash);
+	}
+
+	/**
+	 * Returns a QR code PNG image encoding the join URL for the given room.
+	 * <p>
+	 * No authentication is required — anyone who has the session code can
+	 * retrieve the QR code. Returns 404 if the room does not exist.
+	 * </p>
+	 *
+	 * @param sessionCode the public session code of the room
+	 * @return a {@link ResponseEntity} containing the PNG image bytes with content-type {@code image/png}
+	 */
+	@Operation(
+		summary = "Get QR code for a bingo room",
+		description = "Returns a 250x250 PNG QR code that encodes the join URL for the given room. "
+			+ "No authentication required. Returns 404 if the room does not exist."
+	)
+	@ApiResponses({
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(
+			responseCode = "200",
+			description = "QR code PNG image",
+			content = @Content(mediaType = "image/png")
+		),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(
+			responseCode = "404",
+			description = "Room not found for the given session code",
+			content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponse.class))
+		)
+	})
+	@GetMapping(value = "/{session-code}/qrcode", produces = MediaType.IMAGE_PNG_VALUE)
+	public ResponseEntity<byte[]> getQrCode(
+		@Parameter(description = "Public session code of the room", required = true)
+		@PathVariable("session-code") String sessionCode) {
+		roomService.findRoomBySessionCode(sessionCode, null);
+		byte[] imageBytes = qrCodeService.generateQrCodeForRoom(sessionCode);
+		return ResponseEntity.ok()
+			.contentType(MediaType.IMAGE_PNG)
+			.body(imageBytes);
 	}
 
 }

--- a/src/main/java/com/yanajiki/application/bingoapp/service/QrCodeService.java
+++ b/src/main/java/com/yanajiki/application/bingoapp/service/QrCodeService.java
@@ -1,0 +1,77 @@
+package com.yanajiki.application.bingoapp.service;
+
+import com.google.zxing.BarcodeFormat;
+import com.google.zxing.WriterException;
+import com.google.zxing.client.j2se.MatrixToImageWriter;
+import com.google.zxing.common.BitMatrix;
+import com.google.zxing.qrcode.QRCodeWriter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+/**
+ * Service responsible for generating QR code images for bingo rooms.
+ * <p>
+ * Builds a join URL from the configured base URL and a room's session code,
+ * then encodes that URL as a PNG QR code using the ZXing library.
+ * </p>
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class QrCodeService {
+
+	/** Size (width and height) of the generated QR code image in pixels. */
+	private static final int QR_CODE_SIZE = 250;
+
+	/** Image format written to the output stream. */
+	private static final String IMAGE_FORMAT = "PNG";
+
+	@Value("${app.join-base-url}")
+	private String joinBaseUrl;
+
+	/**
+	 * Generates a QR code PNG image encoding the join URL for the given room.
+	 *
+	 * @param sessionCode the public session code of the room
+	 * @return a byte array containing the PNG image data
+	 * @throws IllegalStateException if QR code generation fails due to an internal ZXing or I/O error
+	 */
+	public byte[] generateQrCodeForRoom(String sessionCode) {
+		String joinUrl = buildJoinUrl(sessionCode);
+		log.debug("Generating QR code for URL '{}'", joinUrl);
+
+		try {
+			QRCodeWriter writer = new QRCodeWriter();
+			BitMatrix bitMatrix = writer.encode(joinUrl, BarcodeFormat.QR_CODE, QR_CODE_SIZE, QR_CODE_SIZE);
+
+			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+			MatrixToImageWriter.writeToStream(bitMatrix, IMAGE_FORMAT, outputStream);
+
+			byte[] imageBytes = outputStream.toByteArray();
+			log.debug("QR code generated successfully for session code '{}', size={} bytes", sessionCode, imageBytes.length);
+			return imageBytes;
+
+		} catch (WriterException | IOException e) {
+			log.error("Failed to generate QR code for session code '{}'", sessionCode, e);
+			throw new IllegalStateException("Failed to generate QR code for session code: " + sessionCode, e);
+		}
+	}
+
+	/**
+	 * Builds the full join URL for a given room session code.
+	 * <p>
+	 * Package-private to allow direct testing without Spring context wiring.
+	 * </p>
+	 *
+	 * @param sessionCode the public session code of the room
+	 * @return the full join URL as a string, e.g. {@code http://localhost:8080/join/ABC123}
+	 */
+	String buildJoinUrl(String sessionCode) {
+		return joinBaseUrl + "/" + sessionCode;
+	}
+}

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -16,3 +16,6 @@ spring.h2.console.enabled=false
 
 # CORS — restrict to explicit origins in production
 app.cors.allowed-origins=${CORS_ALLOWED_ORIGINS:http://localhost:3000}
+
+# QR Code — join URL base (required in production)
+app.join-base-url=${JOIN_BASE_URL:https://yourdomain.com/join}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,3 +14,6 @@ spring.devtools.restart.additional-paths=file:src/main/resources/static/
 # SpringDoc / OpenAPI
 springdoc.api-docs.path=/api-docs
 springdoc.swagger-ui.path=/swagger-ui.html
+
+# QR Code — join URL base (override per profile if needed)
+app.join-base-url=http://localhost:8080/join

--- a/src/test/java/com/yanajiki/application/bingoapp/api/RoomControllerIntegrationTest.java
+++ b/src/test/java/com/yanajiki/application/bingoapp/api/RoomControllerIntegrationTest.java
@@ -257,4 +257,50 @@ class RoomControllerIntegrationTest {
 			.body("status", equalTo(404))
 			.body("message", notNullValue());
 	}
+
+	// ─── GET /api/v1/room/{session-code}/qrcode ──────────────────────────────
+
+	/**
+	 * Requesting the QR code for an existing room returns HTTP 200
+	 * with content-type {@code image/png}.
+	 */
+	@Test
+	void shouldReturnQrCodePngForExistingRoom() {
+		// Arrange: create a room and capture its sessionCode
+		String sessionCode = given()
+			.contentType(ContentType.JSON)
+			.body("""
+				{
+					"name": "QR Code Room"
+				}
+				""")
+		.when()
+			.post("/api/v1/room")
+		.then()
+			.statusCode(200)
+			.extract()
+			.path("sessionCode");
+
+		// Act & Assert: QR code endpoint returns a PNG image
+		given()
+		.when()
+			.get("/api/v1/room/{sessionCode}/qrcode", sessionCode)
+		.then()
+			.statusCode(200)
+			.contentType("image/png");
+	}
+
+	/**
+	 * Requesting the QR code for a session code that does not exist returns HTTP 404 NOT FOUND.
+	 */
+	@Test
+	void shouldReturn404WhenQrCodeRequestedForNonExistentRoom() {
+		given()
+		.when()
+			.get("/api/v1/room/{sessionCode}/qrcode", "INVALID")
+		.then()
+			.statusCode(404)
+			.body("status", equalTo(404))
+			.body("message", notNullValue());
+	}
 }

--- a/src/test/java/com/yanajiki/application/bingoapp/service/QrCodeServiceTest.java
+++ b/src/test/java/com/yanajiki/application/bingoapp/service/QrCodeServiceTest.java
@@ -1,0 +1,108 @@
+package com.yanajiki.application.bingoapp.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link QrCodeService}.
+ * <p>
+ * Verifies URL construction and QR code PNG generation without spinning up
+ * the full Spring context. The {@code joinBaseUrl} field is injected directly
+ * via {@link ReflectionTestUtils} to avoid Spring's {@code @Value} wiring.
+ * </p>
+ */
+@ExtendWith(MockitoExtension.class)
+class QrCodeServiceTest {
+
+	private QrCodeService qrCodeService;
+
+	@BeforeEach
+	void setUp() {
+		qrCodeService = new QrCodeService();
+		ReflectionTestUtils.setField(qrCodeService, "joinBaseUrl", "http://localhost:8080/join");
+	}
+
+	// ─── buildJoinUrl ──────────────────────────────────────────────────────────
+
+	@Nested
+	@DisplayName("buildJoinUrl")
+	class BuildJoinUrl {
+
+		/**
+		 * The join URL must be a concatenation of the base URL and the session code
+		 * separated by a forward slash.
+		 */
+		@Test
+		@DisplayName("returns base URL concatenated with session code")
+		void returnsBaseUrlConcatenatedWithSessionCode() {
+			// when
+			String url = qrCodeService.buildJoinUrl("ABC123");
+
+			// then
+			assertThat(url).isEqualTo("http://localhost:8080/join/ABC123");
+		}
+
+		/**
+		 * Different session codes must produce distinct join URLs, confirming the
+		 * session code is appended dynamically each time.
+		 */
+		@Test
+		@DisplayName("different session codes produce different URLs")
+		void differentSessionCodesProduceDifferentUrls() {
+			// when
+			String url1 = qrCodeService.buildJoinUrl("AAAAAA");
+			String url2 = qrCodeService.buildJoinUrl("BBBBBB");
+
+			// then
+			assertThat(url1).isNotEqualTo(url2);
+			assertThat(url1).endsWith("/AAAAAA");
+			assertThat(url2).endsWith("/BBBBBB");
+		}
+	}
+
+	// ─── generateQrCodeForRoom ────────────────────────────────────────────────
+
+	@Nested
+	@DisplayName("generateQrCodeForRoom")
+	class GenerateQrCodeForRoom {
+
+		/**
+		 * The method must return a non-empty byte array.
+		 * Any valid PNG QR code will always have bytes.
+		 */
+		@Test
+		@DisplayName("returns non-empty byte array")
+		void returnsNonEmptyByteArray() {
+			// when
+			byte[] result = qrCodeService.generateQrCodeForRoom("ABC123");
+
+			// then
+			assertThat(result).isNotEmpty();
+		}
+
+		/**
+		 * The returned bytes must begin with the PNG magic number {@code 0x89504E47}
+		 * (the four-byte signature that every valid PNG file starts with).
+		 */
+		@Test
+		@DisplayName("returned bytes start with PNG magic number (0x89504E47)")
+		void returnedBytesStartWithPngMagicNumber() {
+			// when
+			byte[] result = qrCodeService.generateQrCodeForRoom("ABC123");
+
+			// then — PNG magic bytes: 0x89 0x50 0x4E 0x47
+			assertThat(result).hasSizeGreaterThan(4);
+			assertThat(result[0]).isEqualTo((byte) 0x89);
+			assertThat(result[1]).isEqualTo((byte) 0x50);
+			assertThat(result[2]).isEqualTo((byte) 0x4E);
+			assertThat(result[3]).isEqualTo((byte) 0x47);
+		}
+	}
+}


### PR DESCRIPTION
New GET /api/v1/room/{session-code}/qrcode endpoint returns a 250x250 PNG QR code encoding a configurable join URL, allowing players to scan and join rooms directly from the owner's screen.