### PR TITLE
feat(api): automatic draw game mode

### DIFF
--- a/.tasks/active/automatic-draw/001-drawmode-enum-entity.md
+++ b/.tasks/active/automatic-draw/001-drawmode-enum-entity.md
@@ -1,0 +1,81 @@
+# 001 — DrawMode Enum + RoomEntity Update
+
+## What to build
+Create a `DrawMode` enum (`MANUAL`, `AUTOMATIC`) and add a `drawMode` field to `RoomEntity`. Update the entity factory method to accept draw mode. Update entity tests.
+
+## Acceptance Criteria
+- [ ] `DrawMode` enum exists with `MANUAL` and `AUTOMATIC` values
+- [ ] `RoomEntity` has a `drawMode` field, persisted as STRING, defaults to `MANUAL`
+- [ ] `RoomEntity.createEntityObject()` accepts an optional `drawMode` parameter (overloaded or default)
+- [ ] Entity tests cover the new field
+- [ ] All existing tests still pass
+
+## Technical Spec
+
+### Files to CREATE
+| File | Package/Path | Purpose |
+|------|-------------|---------|
+| `DrawMode.java` | `com.yanajiki.application.bingoapp.game` | Enum with MANUAL, AUTOMATIC values |
+
+### Files to MODIFY
+| File | Change |
+|------|--------|
+| `RoomEntity.java` | Add `drawMode` field with `@Enumerated(EnumType.STRING)`, default `MANUAL`. Add overloaded factory method |
+| `RoomEntityTest.java` | Add tests for drawMode field in entity creation |
+
+### Files to READ (for patterns — do NOT modify)
+| File | What to copy |
+|------|-------------|
+| `RoomEntity.java` | Lombok annotations, entity structure, factory method pattern |
+| `RoomEntityTest.java` | Test structure, @Nested, @DisplayName conventions |
+| `StandardBingoMapper.java` | Package location reference for game package |
+
+### Implementation Details
+
+**DrawMode.java:**
+```java
+package com.yanajiki.application.bingoapp.game;
+
+/**
+ * Defines the draw mode for a bingo room.
+ * MANUAL: creator selects a specific number to draw.
+ * AUTOMATIC: server randomly selects the next number from the remaining pool.
+ */
+public enum DrawMode {
+	MANUAL,
+	AUTOMATIC
+}
+```
+
+**RoomEntity changes:**
+- Add field:
+  ```java
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private DrawMode drawMode;
+  ```
+- Add overloaded factory method:
+  ```java
+  public static RoomEntity createEntityObject(String name, String description, DrawMode drawMode)
+  ```
+- Keep existing factory method, default to `DrawMode.MANUAL`:
+  ```java
+  public static RoomEntity createEntityObject(String name, String description) {
+      return createEntityObject(name, description, DrawMode.MANUAL);
+  }
+  ```
+
+### Conventions (from project CLAUDE.md)
+- Tabs for indentation, camelCase naming
+- Lombok for boilerplate (@Getter, @Setter, @NoArgsConstructor, etc.)
+- Javadoc on all classes and public methods
+- JUnit 5 + @Nested + @DisplayName for test organization
+
+## TDD Sequence
+1. Write `DrawMode.java` enum (trivial, no test needed for enum)
+2. Write new tests in `RoomEntityTest.java` for drawMode field
+3. Modify `RoomEntity.java` to make tests pass
+4. Run `mvn test` — all tests must pass
+
+## Done Definition
+All acceptance criteria checked. Tests green. No compilation warnings.

--- a/.tasks/active/automatic-draw/002-form-dto-updates.md
+++ b/.tasks/active/automatic-draw/002-form-dto-updates.md
@@ -1,0 +1,84 @@
+# 002 — CreateRoomForm + RoomDTO Updates
+
+## What to build
+Add `drawMode` field to `CreateRoomForm` (optional, defaults to MANUAL) and to `RoomDTO` response. Update `RoomService.createRoom()` to pass draw mode to entity. Update all affected existing tests.
+
+## Acceptance Criteria
+- [ ] `CreateRoomForm` has an optional `drawMode` field (defaults to MANUAL when null)
+- [ ] `RoomDTO` includes `drawMode` in both creator and player views
+- [ ] `RoomService.createRoom()` passes drawMode from form to entity factory
+- [ ] All existing tests updated and passing
+- [ ] Swagger/OpenAPI docs reflect the new field
+
+## Technical Spec
+
+### Files to MODIFY
+| File | Change |
+|------|--------|
+| `CreateRoomForm.java` | Add `DrawMode drawMode` field (nullable, service defaults to MANUAL) |
+| `RoomDTO.java` | Add `DrawMode drawMode` parameter to record. Update both factory methods |
+| `RoomService.java` | In `createRoom()`, read drawMode from form, default to MANUAL if null, pass to entity factory |
+| `RoomServiceTest.java` | Update existing tests for new drawMode field in DTOs and entity creation |
+| `RoomControllerIntegrationTest.java` | Update assertions to include drawMode in responses |
+
+### Files to READ (for patterns — do NOT modify unless listed above)
+| File | What to copy |
+|------|-------------|
+| `CreateRoomForm.java` | Existing validation annotation patterns |
+| `RoomDTO.java` | Record structure, factory method pattern |
+| `RoomService.java` | createRoom method flow |
+| `RoomServiceTest.java` | Test patterns, mock setup |
+| `RoomControllerIntegrationTest.java` | RestAssured assertion patterns |
+
+### Implementation Details
+
+**CreateRoomForm changes:**
+```java
+// Add field (no @NotNull — it's optional, service handles default)
+private DrawMode drawMode;
+```
+
+**RoomDTO changes:**
+```java
+public record RoomDTO(
+    String name,
+    String description,
+    String sessionCode,
+    @JsonInclude(JsonInclude.Include.NON_NULL) String creatorHash,
+    List<Integer> drawnNumbers,
+    List<String> drawnLabels,
+    DrawMode drawMode  // new field
+) {
+    public static RoomDTO fromEntityToCreator(RoomEntity entity, NumberLabelMapper mapper) {
+        return new RoomDTO(
+            entity.getName(), entity.getDescription(), entity.getSessionCode(),
+            entity.getCreatorHash(), entity.getDrawnNumbers(),
+            toLabels(entity.getDrawnNumbers(), mapper),
+            entity.getDrawMode()
+        );
+    }
+    // Same pattern for fromEntityToPlayer — include drawMode
+}
+```
+
+**RoomService.createRoom() change:**
+```java
+DrawMode mode = form.getDrawMode() != null ? form.getDrawMode() : DrawMode.MANUAL;
+RoomEntity entity = RoomEntity.createEntityObject(form.getName(), form.getDescription(), mode);
+```
+
+### Conventions (from project CLAUDE.md)
+- Tabs for indentation, camelCase naming
+- Records for DTOs
+- Lombok on forms
+- Javadoc on all classes and public methods
+- @JsonInclude(NON_NULL) for fields hidden in certain views (creatorHash pattern)
+
+## TDD Sequence
+1. Update `RoomServiceTest.java` — update mock returns and assertions to include drawMode
+2. Update `CreateRoomForm.java`, `RoomDTO.java`, `RoomService.java` to make tests pass
+3. Update `RoomControllerIntegrationTest.java` assertions
+4. Run `mvn test` — all tests must pass
+
+## Done Definition
+All acceptance criteria checked. Tests green. No compilation warnings.

--- a/.tasks/active/automatic-draw/003-service-random-draw.md
+++ b/.tasks/active/automatic-draw/003-service-random-draw.md
@@ -1,0 +1,102 @@
+# 003 — RoomService.drawRandomNumber() + Unit Tests
+
+## What to build
+Add `drawRandomNumber(sessionCode, creatorHash)` method to `RoomService` that picks a random undrawn number from the 1-75 pool. Add mode enforcement: `drawNumber()` rejects calls on AUTOMATIC rooms, `drawRandomNumber()` rejects calls on MANUAL rooms. Write unit tests first (TDD).
+
+## Acceptance Criteria
+- [ ] `drawRandomNumber(sessionCode, creatorHash)` selects a random number from remaining pool
+- [ ] Returns player-view `RoomDTO` with the new number included
+- [ ] Throws `RoomNotFoundException` if room/creator not found
+- [ ] Throws `IllegalStateException` if all 75 numbers already drawn
+- [ ] Throws `IllegalArgumentException` if called on a MANUAL room ("This room uses manual draw mode")
+- [ ] Existing `drawNumber()` throws `IllegalArgumentException` if called on an AUTOMATIC room ("This room uses automatic draw mode")
+- [ ] Unit tests cover: happy path, all-numbers-drawn, wrong mode, room not found
+- [ ] All existing tests still pass
+
+## Technical Spec
+
+### Files to MODIFY
+| File | Change |
+|------|--------|
+| `RoomService.java` | Add `drawRandomNumber()` method. Add mode enforcement to both draw methods |
+| `RoomServiceTest.java` | Add new @Nested class for automatic draw tests. Add mode enforcement tests to existing draw tests |
+
+### Files to READ (for patterns — do NOT modify unless listed above)
+| File | What to copy |
+|------|-------------|
+| `RoomService.java` | Existing `drawNumber()` pattern, repository usage, validation pattern |
+| `RoomServiceTest.java` | Mock setup, @Nested structure, assertion patterns |
+| `NumberLabelMapper.java` | `getMinNumber()`, `getMaxNumber()` interface |
+
+### Implementation Details
+
+**RoomService.drawRandomNumber():**
+```java
+/**
+ * Draws a random number from the remaining pool for automatic draw mode rooms.
+ *
+ * @param sessionCode the room session code
+ * @param creatorHash the creator's hash for authentication
+ * @return player-view RoomDTO with updated drawn numbers
+ * @throws RoomNotFoundException if room not found or creator hash doesn't match
+ * @throws IllegalArgumentException if room is not in AUTOMATIC draw mode
+ * @throws IllegalStateException if all numbers have been drawn
+ */
+public RoomDTO drawRandomNumber(String sessionCode, String creatorHash) {
+    RoomEntity entity = roomRepository.findBySessionCodeAndCreatorHash(sessionCode, creatorHash)
+        .orElseThrow(() -> new RoomNotFoundException("Room not found"));
+
+    if (entity.getDrawMode() != DrawMode.AUTOMATIC) {
+        throw new IllegalArgumentException("This room uses manual draw mode");
+    }
+
+    int number = selectRandomNumber(entity);
+    entity.addDrawnNumber(number);
+    roomRepository.save(entity);
+    return RoomDTO.fromEntityToPlayer(entity, numberLabelMapper);
+}
+
+private int selectRandomNumber(RoomEntity entity) {
+    List<Integer> remaining = IntStream.rangeClosed(
+            numberLabelMapper.getMinNumber(), numberLabelMapper.getMaxNumber())
+        .filter(n -> !entity.getDrawnNumbers().contains(n))
+        .boxed()
+        .toList();
+
+    if (remaining.isEmpty()) {
+        throw new IllegalStateException("All numbers have been drawn");
+    }
+
+    return remaining.get(new SecureRandom().nextInt(remaining.size()));
+}
+```
+
+**Mode enforcement in existing drawNumber():**
+Add at the start of `drawNumber()`, after finding the entity:
+```java
+if (entity.getDrawMode() != DrawMode.MANUAL) {
+    throw new IllegalArgumentException("This room uses automatic draw mode");
+}
+```
+
+**Exception handling note:**
+`IllegalStateException` for "all numbers drawn" — add to `GlobalExceptionHandler` mapping to 409 Conflict (or 400 Bad Request — use 409 since it's a state conflict). Actually, map it to 400 since it's a bad request given the current state.
+
+### Conventions (from project CLAUDE.md)
+- Tabs for indentation, camelCase naming
+- SLF4J for logging
+- Javadoc on all public methods
+- SecureRandom for randomness (consistent with existing sessionCode generation)
+- Unit tests: JUnit 5 + Mockito, @Nested + @DisplayName
+- `mvn test` runs automatically via PostToolUse hook — do NOT run it manually
+
+## TDD Sequence
+1. Write new tests in `RoomServiceTest.java`:
+   - @Nested class `DrawRandomNumber` with: happy path, all-drawn, wrong-mode, room-not-found
+   - Add mode enforcement test to existing `DrawNumber` nested class
+2. Implement `drawRandomNumber()` and mode enforcement in `RoomService.java`
+3. Add `IllegalStateException` handler in `GlobalExceptionHandler.java` → 400 or 409
+4. Tests must pass (mvn test runs automatically)
+
+## Done Definition
+All acceptance criteria checked. Tests green. No compilation warnings.

--- a/.tasks/active/automatic-draw/004-websocket-controller.md
+++ b/.tasks/active/automatic-draw/004-websocket-controller.md
@@ -1,0 +1,96 @@
+# 004 — DrawNumberForm + WebSocketController + Mode Enforcement
+
+## What to build
+Create `DrawNumberForm` (session-code + creator-hash only, no number). Add new `@MessageMapping("/draw-number")` endpoint to `WebSocketController` that calls `RoomService.drawRandomNumber()` and broadcasts the result. Add mode enforcement: `/add-number` only works for MANUAL rooms, `/draw-number` only works for AUTOMATIC rooms (enforced at service layer already, controller just delegates).
+
+## Acceptance Criteria
+- [ ] `DrawNumberForm` record with sessionCode and creatorHash fields, with validation
+- [ ] New `/draw-number` WebSocket mapping in `WebSocketController`
+- [ ] Broadcasts updated `RoomDTO` (player view) to `/room/{sessionCode}`
+- [ ] Existing `/add-number` endpoint unchanged
+- [ ] All tests pass
+
+## Technical Spec
+
+### Files to CREATE
+| File | Package/Path | Purpose |
+|------|-------------|---------|
+| `DrawNumberForm.java` | `com.yanajiki.application.bingoapp.websocket.form` | WebSocket payload for automatic draw |
+
+### Files to MODIFY
+| File | Change |
+|------|--------|
+| `WebSocketController.java` | Add `drawRandomNumber()` method with `@MessageMapping("/draw-number")` |
+
+### Files to READ (for patterns — do NOT modify unless listed above)
+| File | What to copy |
+|------|-------------|
+| `WebSocketController.java` | Existing `drawNumber()` pattern, messaging template usage |
+| `AddNumberForm.java` | Form structure, validation annotations, @JsonProperty naming |
+
+### Implementation Details
+
+**DrawNumberForm.java:**
+```java
+package com.yanajiki.application.bingoapp.websocket.form;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * WebSocket payload for automatic number draw.
+ * Only requires session identification and creator authentication — no number needed.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DrawNumberForm {
+
+	@NotBlank
+	@JsonProperty("session-code")
+	private String sessionCode;
+
+	@NotBlank
+	@JsonProperty("creator-hash")
+	private String creatorHash;
+}
+```
+
+**WebSocketController addition:**
+```java
+/**
+ * Draws a random number for automatic draw mode rooms.
+ * Picks a random undrawn number and broadcasts the updated room state.
+ *
+ * @param message the draw request containing session code and creator hash
+ */
+@MessageMapping("/draw-number")
+public void drawRandomNumber(DrawNumberForm message) {
+    log.info("Automatic draw requested for room: {}", message.getSessionCode());
+    RoomDTO roomDTO = roomService.drawRandomNumber(
+        message.getSessionCode(), message.getCreatorHash());
+    messagingTemplate.convertAndSend(
+        "/room/" + message.getSessionCode(), roomDTO);
+}
+```
+
+### Conventions (from project CLAUDE.md)
+- Tabs for indentation, camelCase naming
+- Lombok on form classes
+- @JsonProperty with kebab-case for WebSocket JSON payloads
+- SLF4J logging at INFO level for draw operations
+- Javadoc on all classes and public methods
+- Controllers are thin — delegate everything to service
+
+## TDD Sequence
+1. Create `DrawNumberForm.java`
+2. Add `drawRandomNumber()` method to `WebSocketController.java`
+3. Run `mvn test` — all tests must pass (integration tests in task 005 will cover this endpoint)
+
+## Done Definition
+All acceptance criteria checked. Tests green. No compilation warnings.

--- a/.tasks/active/automatic-draw/005-integration-tests.md
+++ b/.tasks/active/automatic-draw/005-integration-tests.md
@@ -1,0 +1,84 @@
+# 005 — Integration Tests for Automatic Draw
+
+## What to build
+Write integration tests covering the full automatic draw feature: room creation with AUTOMATIC mode, the draw endpoint behavior, and mode enforcement at the API level. Tests use RestAssured with H2 on dev profile.
+
+## Acceptance Criteria
+- [ ] Test: create room with `drawMode: AUTOMATIC` — response includes drawMode
+- [ ] Test: create room without drawMode — defaults to MANUAL in response
+- [ ] Test: GET room returns drawMode in response (both creator and player views)
+- [ ] All new tests pass alongside existing tests
+- [ ] No existing tests broken
+
+## Technical Spec
+
+### Files to MODIFY
+| File | Change |
+|------|--------|
+| `RoomControllerIntegrationTest.java` | Add new @Nested class for automatic draw mode tests. Update existing tests if drawMode field needs asserting |
+
+### Files to READ (for patterns — do NOT modify unless listed above)
+| File | What to copy |
+|------|-------------|
+| `RoomControllerIntegrationTest.java` | RestAssured patterns, given/when/then style, test setup |
+| `CreateRoomForm.java` | Current form fields for request body construction |
+| `RoomDTO.java` | Response fields for assertion |
+
+### Implementation Details
+
+**New tests to add in `RoomControllerIntegrationTest.java`:**
+
+```java
+@Nested
+@DisplayName("Automatic Draw Mode")
+class AutomaticDrawMode {
+
+    @Test
+    @DisplayName("should create room with AUTOMATIC draw mode")
+    void shouldCreateRoomWithAutomaticDrawMode() {
+        // POST /api/v1/room with {"name": "Auto Room", "drawMode": "AUTOMATIC"}
+        // Assert response contains drawMode: "AUTOMATIC"
+    }
+
+    @Test
+    @DisplayName("should default to MANUAL draw mode when not specified")
+    void shouldDefaultToManualDrawMode() {
+        // POST /api/v1/room with {"name": "Default Room"}
+        // Assert response contains drawMode: "MANUAL"
+    }
+
+    @Test
+    @DisplayName("should return drawMode in GET room response for creator")
+    void shouldReturnDrawModeInCreatorView() {
+        // Create automatic room, then GET with X-Creator-Hash
+        // Assert drawMode: "AUTOMATIC" in response
+    }
+
+    @Test
+    @DisplayName("should return drawMode in GET room response for player")
+    void shouldReturnDrawModeInPlayerView() {
+        // Create automatic room, then GET without X-Creator-Hash
+        // Assert drawMode: "AUTOMATIC" in response
+    }
+}
+```
+
+**Note on WebSocket testing:**
+WebSocket integration tests are complex and out of scope for this task. The WebSocket draw functionality is covered by:
+- Unit tests on `RoomService.drawRandomNumber()` (task 003)
+- Controller is thin (just delegates to service + broadcasts)
+
+### Conventions (from project CLAUDE.md)
+- RestAssured with BDD given/when/then style
+- Business-language test names with @DisplayName
+- @Nested for grouping related tests
+- H2 in-memory DB (dev profile) for integration tests
+- `mvn test` runs automatically via PostToolUse hook — do NOT run it manually
+
+## TDD Sequence
+1. Write integration tests first (they will fail)
+2. If any adjustments needed in implementation, make them
+3. Run `mvn test` — all tests must pass
+
+## Done Definition
+All acceptance criteria checked. Tests green. No compilation warnings.

--- a/.tasks/active/automatic-draw/INDEX.md
+++ b/.tasks/active/automatic-draw/INDEX.md
@@ -1,0 +1,21 @@
+# Feature: Automatic Draw Game Mode
+
+**Status**: ready
+**Blocked by feature**: —
+**Branch**: feature/automatic-draw
+
+## Tasks
+
+| ID | Task | Status | Blocked By | Assignee |
+|----|------|--------|------------|----------|
+| 001 | DrawMode enum + RoomEntity update + entity tests | done | — | Implementer |
+| 002 | CreateRoomForm + RoomDTO updates + update existing tests | done | 001 | Implementer |
+| 003 | RoomService.drawRandomNumber() + unit tests | done | 001 | Implementer |
+| 004 | DrawNumberForm + WebSocketController + mode enforcement | done | 003 | Implementer |
+| 005 | Integration tests for automatic draw flow | done | 004 | Implementer |
+
+## Decisions
+- Draw mode is enforced per room: MANUAL rooms only use `/add-number`, AUTOMATIC rooms only use `/draw-number`
+- DrawMode defaults to MANUAL for backward compatibility
+- Random selection uses SecureRandom, picks from remaining pool [1-75] minus drawn numbers
+- Drawing stays WebSocket-only (no REST endpoint for draw)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ com.yanajiki.application.bingoapp/
   exception/      # Custom exceptions + GlobalExceptionHandler (@RestControllerAdvice)
   websocket/      # STOMP WebSocket controller + config
   config/         # CORS config, OpenAPI config
-  game/           # NumberLabelMapper interface + StandardBingoMapper (75-ball bingo rules)
+  game/           # NumberLabelMapper interface + StandardBingoMapper (75-ball bingo rules) + DrawMode enum
 ```
 
 ### Key Design Decisions
@@ -57,15 +57,19 @@ com.yanajiki.application.bingoapp/
 - **Drawn numbers** stored via `@ElementCollection` (separate `room_drawn_numbers` table), not CSV.
 - **Creator identity**: `creatorHash` (UUID) passed in `X-Creator-Hash` header for privileged operations (draw, delete). `sessionCode` (6-char alphanumeric via `SecureRandom`) is the public room identifier.
 - **Two DTO views**: `RoomDTO.fromEntityToCreator()` includes creatorHash; `RoomDTO.fromEntityToPlayer()` hides it via `@JsonInclude(NON_NULL)`.
+- **Draw modes**: `DrawMode` enum (`MANUAL`, `AUTOMATIC`) stored per room. Manual mode: creator picks exact number. Automatic mode: server picks random number from remaining pool. Mode is enforced — each room only accepts its designated draw endpoint.
 
 ### API Endpoints
 
 | Method | Path | Description | Auth |
 |--------|------|-------------|------|
-| POST | `/api/v1/room` | Create room | None |
+| POST | `/api/v1/room` | Create room (optional `drawMode`: `MANUAL`/`AUTOMATIC`, defaults `MANUAL`) | None |
 | GET | `/api/v1/room/{session-code}` | Get room | `X-Creator-Hash` header (optional, determines view) |
 | DELETE | `/api/v1/room/{session-code}` | Delete room | `X-Creator-Hash` header (required) |
-| WS | `/bingo-connect` → `/app/add-number` | Draw number (broadcasts to `/room/{sessionCode}`) | creatorHash in payload |
+| WS | `/bingo-connect` → `/app/add-number` | Manual draw: creator picks number (MANUAL rooms only) | creatorHash in payload |
+| WS | `/bingo-connect` → `/app/draw-number` | Automatic draw: server picks random number (AUTOMATIC rooms only) | creatorHash in payload |
+
+Both WS draw endpoints broadcast the updated `RoomDTO` (player view) to `/room/{sessionCode}`.
 
 ### Exception Handling
 
@@ -73,7 +77,8 @@ Centralized in `GlobalExceptionHandler`:
 - `ConflictException` -> 409 (duplicate room name)
 - `RoomNotFoundException` -> 404
 - `MethodArgumentNotValidException` -> 400 (validation errors)
-- `IllegalArgumentException` -> 400 (business rule violation)
+- `IllegalArgumentException` -> 400 (business rule violation, including draw mode mismatch)
+- `IllegalStateException` -> 400 (e.g., all numbers already drawn)
 - Generic `Exception` -> 500 (logged at ERROR)
 
 ## Spring Profiles

--- a/src/main/java/com/yanajiki/application/bingoapp/api/form/CreateRoomForm.java
+++ b/src/main/java/com/yanajiki/application/bingoapp/api/form/CreateRoomForm.java
@@ -1,5 +1,6 @@
 package com.yanajiki.application.bingoapp.api.form;
 
+import com.yanajiki.application.bingoapp.game.DrawMode;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
@@ -11,6 +12,9 @@ import lombok.Setter;
  * <p>
  * Kept as a mutable class (not a record) so that Jackson can deserialize it
  * without requiring a fully-qualified constructor call.
+ * </p>
+ * <p>
+ * {@code drawMode} is optional; when omitted (null), the service defaults to {@link DrawMode#MANUAL}.
  * </p>
  */
 @NoArgsConstructor
@@ -26,4 +30,11 @@ public class CreateRoomForm {
 	/** An optional description for the room. At most 255 characters. */
 	@Size(max = 255)
 	private String description;
+
+	/**
+	 * The draw mode for the room. Optional — if not provided, the service defaults to
+	 * {@link DrawMode#MANUAL}. Use {@link DrawMode#AUTOMATIC} to enable server-side
+	 * random number drawing.
+	 */
+	private DrawMode drawMode;
 }

--- a/src/main/java/com/yanajiki/application/bingoapp/api/response/RoomDTO.java
+++ b/src/main/java/com/yanajiki/application/bingoapp/api/response/RoomDTO.java
@@ -2,6 +2,7 @@ package com.yanajiki.application.bingoapp.api.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.yanajiki.application.bingoapp.database.RoomEntity;
+import com.yanajiki.application.bingoapp.game.DrawMode;
 import com.yanajiki.application.bingoapp.game.NumberLabelMapper;
 
 import java.util.List;
@@ -26,6 +27,7 @@ import java.util.List;
  * @param creatorHash  the creator's authentication token; {@code null} in player view
  * @param drawnNumbers the list of bingo numbers drawn so far in this room (raw integers)
  * @param drawnLabels  the list of display labels for drawn numbers (e.g., {@code "N-42"})
+ * @param drawMode     the draw mode for the room ({@link DrawMode#MANUAL} or {@link DrawMode#AUTOMATIC})
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record RoomDTO(
@@ -34,7 +36,8 @@ public record RoomDTO(
 	String sessionCode,
 	String creatorHash,
 	List<Integer> drawnNumbers,
-	List<String> drawnLabels
+	List<String> drawnLabels,
+	DrawMode drawMode
 ) {
 
 	/**
@@ -43,7 +46,7 @@ public record RoomDTO(
 	 *
 	 * @param entity the persisted room entity
 	 * @param mapper the {@link NumberLabelMapper} used to produce display labels for drawn numbers
-	 * @return a {@link RoomDTO} with all fields populated, including {@code creatorHash}
+	 * @return a {@link RoomDTO} with all fields populated, including {@code creatorHash} and {@code drawMode}
 	 */
 	public static RoomDTO fromEntityToCreator(RoomEntity entity, NumberLabelMapper mapper) {
 		List<Integer> numbers = entity.getDrawnNumbers();
@@ -53,7 +56,8 @@ public record RoomDTO(
 			entity.getSessionCode(),
 			entity.getCreatorHash(),
 			numbers,
-			toLabels(numbers, mapper)
+			toLabels(numbers, mapper),
+			entity.getDrawMode()
 		);
 	}
 
@@ -63,7 +67,7 @@ public record RoomDTO(
 	 *
 	 * @param entity the persisted room entity
 	 * @param mapper the {@link NumberLabelMapper} used to produce display labels for drawn numbers
-	 * @return a {@link RoomDTO} with {@code creatorHash} set to {@code null}
+	 * @return a {@link RoomDTO} with {@code creatorHash} set to {@code null} and {@code drawMode} populated
 	 */
 	public static RoomDTO fromEntityToPlayer(RoomEntity entity, NumberLabelMapper mapper) {
 		List<Integer> numbers = entity.getDrawnNumbers();
@@ -73,7 +77,8 @@ public record RoomDTO(
 			entity.getSessionCode(),
 			null,
 			numbers,
-			toLabels(numbers, mapper)
+			toLabels(numbers, mapper),
+			entity.getDrawMode()
 		);
 	}
 

--- a/src/main/java/com/yanajiki/application/bingoapp/database/RoomEntity.java
+++ b/src/main/java/com/yanajiki/application/bingoapp/database/RoomEntity.java
@@ -1,6 +1,6 @@
 package com.yanajiki.application.bingoapp.database;
 
-
+import com.yanajiki.application.bingoapp.game.DrawMode;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
@@ -54,6 +54,10 @@ public class RoomEntity {
 	@Column(name = "number")
 	private List<Integer> drawnNumbers = new ArrayList<>();
 
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private DrawMode drawMode;
+
 	@CreationTimestamp
 	@Temporal(TemporalType.TIMESTAMP)
 	private LocalDateTime createDateTime;
@@ -63,13 +67,27 @@ public class RoomEntity {
 	private LocalDateTime updateDateTime;
 
 	/**
-	 * Factory method to create a new {@link RoomEntity} with a generated session code and creator hash.
+	 * Factory method to create a new {@link RoomEntity} with a generated session code and creator hash,
+	 * defaulting to {@link DrawMode#MANUAL}.
 	 *
 	 * @param name        the unique name of the room
 	 * @param description a short description of the room
-	 * @return a new {@link RoomEntity} ready to be persisted
+	 * @return a new {@link RoomEntity} ready to be persisted with {@link DrawMode#MANUAL}
 	 */
 	public static RoomEntity createEntityObject(String name, String description) {
+		return createEntityObject(name, description, DrawMode.MANUAL);
+	}
+
+	/**
+	 * Factory method to create a new {@link RoomEntity} with a generated session code, creator hash,
+	 * and the specified draw mode.
+	 *
+	 * @param name        the unique name of the room
+	 * @param description a short description of the room
+	 * @param drawMode    the draw mode for the room ({@link DrawMode#MANUAL} or {@link DrawMode#AUTOMATIC})
+	 * @return a new {@link RoomEntity} ready to be persisted
+	 */
+	public static RoomEntity createEntityObject(String name, String description, DrawMode drawMode) {
 		String creatorHash = UUID.randomUUID().toString();
 
 		RoomEntity roomEntity = new RoomEntity();
@@ -80,6 +98,7 @@ public class RoomEntity {
 		roomEntity.setUpdateDateTime(LocalDateTime.now());
 		roomEntity.setDrawnNumbers(new ArrayList<>());
 		roomEntity.setSessionCode(newSessionCode());
+		roomEntity.setDrawMode(drawMode);
 		return roomEntity;
 	}
 

--- a/src/main/java/com/yanajiki/application/bingoapp/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/yanajiki/application/bingoapp/exception/GlobalExceptionHandler.java
@@ -79,6 +79,22 @@ public class GlobalExceptionHandler {
 	}
 
 	/**
+	 * Handles {@link IllegalStateException}, returning HTTP 400 BAD REQUEST.
+	 * <p>
+	 * Used when the current state of the resource makes the operation invalid —
+	 * for example, attempting to draw a number when all numbers have already been drawn.
+	 * </p>
+	 *
+	 * @param ex the illegal state exception thrown by the service layer
+	 * @return a {@link ResponseEntity} containing the error status and message
+	 */
+	@ExceptionHandler(IllegalStateException.class)
+	public ResponseEntity<ApiResponse> handleIllegalState(IllegalStateException ex) {
+		int httpStatus = HttpStatus.BAD_REQUEST.value();
+		return ResponseEntity.status(httpStatus).body(new ApiResponse(httpStatus, ex.getMessage()));
+	}
+
+	/**
 	 * Catch-all handler for any unhandled {@link Exception}, returning HTTP 500 INTERNAL SERVER ERROR.
 	 * <p>
 	 * The full exception is logged at ERROR level. A generic message is returned to the client

--- a/src/main/java/com/yanajiki/application/bingoapp/game/DrawMode.java
+++ b/src/main/java/com/yanajiki/application/bingoapp/game/DrawMode.java
@@ -1,0 +1,23 @@
+package com.yanajiki.application.bingoapp.game;
+
+/**
+ * Defines the draw mode for a bingo room.
+ * <p>
+ * <ul>
+ *   <li>{@link #MANUAL}: the creator selects a specific number to draw.</li>
+ *   <li>{@link #AUTOMATIC}: the server randomly selects the next number from the remaining pool.</li>
+ * </ul>
+ * </p>
+ */
+public enum DrawMode {
+
+	/**
+	 * The room creator manually selects which number to draw each round.
+	 */
+	MANUAL,
+
+	/**
+	 * The server automatically and randomly draws the next available number.
+	 */
+	AUTOMATIC
+}

--- a/src/main/java/com/yanajiki/application/bingoapp/service/RoomService.java
+++ b/src/main/java/com/yanajiki/application/bingoapp/service/RoomService.java
@@ -6,11 +6,16 @@ import com.yanajiki.application.bingoapp.database.RoomEntity;
 import com.yanajiki.application.bingoapp.database.RoomRepository;
 import com.yanajiki.application.bingoapp.exception.ConflictException;
 import com.yanajiki.application.bingoapp.exception.RoomNotFoundException;
+import com.yanajiki.application.bingoapp.game.DrawMode;
 import com.yanajiki.application.bingoapp.game.NumberLabelMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
+
+import java.security.SecureRandom;
+import java.util.List;
+import java.util.stream.IntStream;
 
 /**
  * Service layer for bingo room management.
@@ -41,9 +46,12 @@ public class RoomService {
 	 * and persists a new {@link RoomEntity}. Returns the creator view of the
 	 * room, which includes the {@code creatorHash} needed for administrative actions.
 	 * </p>
+	 * <p>
+	 * If {@code drawMode} is not specified in the form (null), it defaults to {@link DrawMode#MANUAL}.
+	 * </p>
 	 *
-	 * @param form the creation form containing name and description
-	 * @return a {@link RoomDTO} with full creator data, including {@code creatorHash}
+	 * @param form the creation form containing name, description, and optional draw mode
+	 * @return a {@link RoomDTO} with full creator data, including {@code creatorHash} and {@code drawMode}
 	 * @throws ConflictException if a room with the same name already exists
 	 */
 	public RoomDTO createRoom(CreateRoomForm form) {
@@ -54,10 +62,11 @@ public class RoomService {
 					throw new ConflictException("Room already exists.");
 				});
 
-		RoomEntity entity = RoomEntity.createEntityObject(form.getName(), form.getDescription());
+		DrawMode mode = form.getDrawMode() != null ? form.getDrawMode() : DrawMode.MANUAL;
+		RoomEntity entity = RoomEntity.createEntityObject(form.getName(), form.getDescription(), mode);
 		RoomEntity saved = repository.save(entity);
 
-		log.info("Room created successfully with sessionCode '{}'", saved.getSessionCode());
+		log.info("Room created successfully with sessionCode '{}' and drawMode '{}'", saved.getSessionCode(), mode);
 		return RoomDTO.fromEntityToCreator(saved, numberLabelMapper);
 	}
 
@@ -133,6 +142,10 @@ public class RoomService {
 		RoomEntity entity = repository.findBySessionCodeAndCreatorHash(sessionCode, creatorHash)
 				.orElseThrow(() -> new RoomNotFoundException("Room not found."));
 
+		if (entity.getDrawMode() != DrawMode.MANUAL) {
+			throw new IllegalArgumentException("This room uses automatic draw mode");
+		}
+
 		validateDrawnNumber(number, entity);
 
 		entity.addDrawnNumber(number);
@@ -140,6 +153,63 @@ public class RoomService {
 
 		log.info("Number {} drawn in room '{}'", number, sessionCode);
 		return RoomDTO.fromEntityToPlayer(entity, numberLabelMapper);
+	}
+
+	/**
+	 * Draws a random number from the remaining pool for automatic draw mode rooms.
+	 * <p>
+	 * Selects a random number from the set of numbers in [{@code numberLabelMapper.getMinNumber()},
+	 * {@code numberLabelMapper.getMaxNumber()}] that have not yet been drawn. Persists the update
+	 * and returns the player view for broadcasting to connected clients.
+	 * </p>
+	 *
+	 * @param sessionCode the public session code of the room
+	 * @param creatorHash the creator's authentication hash
+	 * @return a {@link RoomDTO} in player view (without {@code creatorHash}) with the new number included
+	 * @throws RoomNotFoundException     if no room matches the given session code and creator hash
+	 * @throws IllegalArgumentException  if the room is not in {@link DrawMode#AUTOMATIC} draw mode
+	 * @throws IllegalStateException     if all numbers in the pool have already been drawn
+	 */
+	public RoomDTO drawRandomNumber(String sessionCode, String creatorHash) {
+		log.info("Drawing random number in room '{}'", sessionCode);
+
+		RoomEntity entity = repository.findBySessionCodeAndCreatorHash(sessionCode, creatorHash)
+				.orElseThrow(() -> new RoomNotFoundException("Room not found"));
+
+		if (entity.getDrawMode() != DrawMode.AUTOMATIC) {
+			throw new IllegalArgumentException("This room uses manual draw mode");
+		}
+
+		int number = selectRandomNumber(entity);
+		entity.addDrawnNumber(number);
+		repository.save(entity);
+
+		log.info("Random number {} drawn in room '{}'", number, sessionCode);
+		return RoomDTO.fromEntityToPlayer(entity, numberLabelMapper);
+	}
+
+	/**
+	 * Selects a random number from the pool of numbers not yet drawn in the given room.
+	 * <p>
+	 * Uses {@link SecureRandom} for selection, consistent with session code generation.
+	 * </p>
+	 *
+	 * @param entity the room entity whose drawn numbers are checked against the full pool
+	 * @return a randomly selected undrawn number
+	 * @throws IllegalStateException if no numbers remain in the pool
+	 */
+	private int selectRandomNumber(RoomEntity entity) {
+		List<Integer> remaining = IntStream.rangeClosed(
+						numberLabelMapper.getMinNumber(), numberLabelMapper.getMaxNumber())
+				.filter(n -> !entity.getDrawnNumbers().contains(n))
+				.boxed()
+				.toList();
+
+		if (remaining.isEmpty()) {
+			throw new IllegalStateException("All numbers have been drawn");
+		}
+
+		return remaining.get(new SecureRandom().nextInt(remaining.size()));
 	}
 
 	/**

--- a/src/main/java/com/yanajiki/application/bingoapp/websocket/WebSocketController.java
+++ b/src/main/java/com/yanajiki/application/bingoapp/websocket/WebSocketController.java
@@ -3,6 +3,7 @@ package com.yanajiki.application.bingoapp.websocket;
 import com.yanajiki.application.bingoapp.api.response.RoomDTO;
 import com.yanajiki.application.bingoapp.service.RoomService;
 import com.yanajiki.application.bingoapp.websocket.form.AddNumberForm;
+import com.yanajiki.application.bingoapp.websocket.form.DrawNumberForm;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -44,5 +45,25 @@ public class WebSocketController {
 
 		log.debug("Broadcasting draw update for room '{}' to topic '{}'", sessionCode, dynamicTopic);
 		messagingTemplate.convertAndSend(dynamicTopic, updatedRoom);
+	}
+
+	/**
+	 * Draws a random number for automatic draw mode rooms.
+	 * <p>
+	 * Delegates to {@link RoomService#drawRandomNumber} to validate the creator, pick a random
+	 * undrawn number, and persist. Broadcasts the updated player-view room state to all subscribers
+	 * of the room's dynamic topic ({@code /room/{sessionCode}}).
+	 * Only works for rooms in AUTOMATIC draw mode — service enforces this constraint.
+	 * </p>
+	 *
+	 * @param message the draw request containing session code and creator hash
+	 */
+	@MessageMapping("/draw-number")
+	public void drawRandomNumber(DrawNumberForm message) {
+		log.info("Automatic draw requested for room: {}", message.getSessionCode());
+		RoomDTO roomDTO = roomService.drawRandomNumber(
+				message.getSessionCode(), message.getCreatorHash());
+		messagingTemplate.convertAndSend(
+				"/room/" + message.getSessionCode(), roomDTO);
 	}
 }

--- a/src/main/java/com/yanajiki/application/bingoapp/websocket/form/DrawNumberForm.java
+++ b/src/main/java/com/yanajiki/application/bingoapp/websocket/form/DrawNumberForm.java
@@ -1,0 +1,32 @@
+package com.yanajiki.application.bingoapp.websocket.form;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * WebSocket payload for automatic number draw.
+ * <p>
+ * Only requires session identification and creator authentication — no number needed.
+ * The number is randomly selected by the service for AUTOMATIC draw mode rooms.
+ * </p>
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DrawNumberForm {
+
+	/** The unique code that identifies the bingo room. */
+	@NotBlank
+	@JsonProperty("session-code")
+	private String sessionCode;
+
+	/** The creator's authentication hash, issued when the room was created. */
+	@NotBlank
+	@JsonProperty("creator-hash")
+	private String creatorHash;
+}

--- a/src/main/resources/static/app.js
+++ b/src/main/resources/static/app.js
@@ -23,11 +23,10 @@ function subscribeToRoom() {
     setTimeout(() => {}, 5000)
     stompClient.subscribe('/room/' + roomSessionCode, (message) => {
         console.log(message.body)
-        let drawnNumbers = JSON.parse(message.body).drawnNumbers
-        let drawnNumbersList = drawnNumbers.split(",");
-        $("#drawn-number").html(`Drawn Number: ${drawnNumbersList[drawnNumbersList.length - 1]}`)
-        $("#all-drawn-numbers").html(`History: ${drawnNumbers}`)
-        console.log(parsedMessage)
+        let room = JSON.parse(message.body);
+        let lastLabel = room.drawnLabels[room.drawnLabels.length - 1];
+        $("#drawn-number").html(`Drawn Number: ${lastLabel}`)
+        $("#all-drawn-numbers").html(`History: ${room.drawnLabels.join(', ')}`)
     });
     localStorage.setItem("sessionCode", roomSessionCode)
 }
@@ -56,6 +55,18 @@ function addNumber() {
    $("#last-number").html(`Last number: ${localStorage.getItem('selectedNumber')}`)
 }
 
+function drawRandomNumber() {
+   $("#btn-draw-random").prop('disabled', true)
+   $("#btn-draw-random").html('Drawing...')
+   stompClient.publish({
+       destination: "/app/draw-number",
+       body: JSON.stringify({
+           "session-code": localStorage.getItem('sessionCode'),
+           "creator-hash": localStorage.getItem('creatorHash'),
+       })
+   });
+}
+
 function selectNumber(number) {
     localStorage.setItem('selectedNumber', number);
     $("#btn-confirmar-numero").prop('disabled', false)
@@ -65,11 +76,12 @@ function selectNumber(number) {
 connect()
 $(function () {
     $("#form-room-submit").click( async () => {
+        let drawMode = $("input[name='drawMode']:checked").val();
         let reqBody = JSON.stringify({
                             'name': $("#form-room-name").val(),
-                            'description': $("#form-room-description").val()
+                            'description': $("#form-room-description").val(),
+                            'drawMode': drawMode
                         })
-//        console.log(reqBody)
 
         await fetch("http://localhost:8080/api/v1/room", {
             method: "POST",
@@ -86,16 +98,29 @@ $(function () {
             console.log("Success:", data);
             localStorage.setItem("creatorHash", data.creatorHash)
             localStorage.setItem("sessionCode", data.sessionCode)
-            $("#GM-interface").prop("style", "display:true");
+            localStorage.setItem("drawMode", data.drawMode)
             $("#room-creator-section").prop("style", "display:none");
-            $("#inviteCode").html(`Invite Code: ${data.sessionCode}`)
 
-            // Handle the response data as needed
+            if (data.drawMode === "AUTOMATIC") {
+                $("#GM-interface-auto").prop("style", "display:true");
+                $("#inviteCodeAuto").html(`Invite Code: ${data.sessionCode}`)
+                // Subscribe to room to receive draw results
+                stompClient.subscribe('/room/' + data.sessionCode, (message) => {
+                    let room = JSON.parse(message.body);
+                    let lastNumber = room.drawnLabels[room.drawnLabels.length - 1];
+                    $("#last-number-auto").html(`Last drawn: ${lastNumber}`)
+                    $("#all-drawn-numbers-auto").html(`History: ${room.drawnLabels.join(', ')}`)
+                    $("#btn-draw-random").prop('disabled', false)
+                    $("#btn-draw-random").html('Draw Number')
+                });
+            } else {
+                $("#GM-interface").prop("style", "display:true");
+                $("#inviteCode").html(`Invite Code: ${data.sessionCode}`)
+            }
         })
         .catch(error => {
             console.error("Error:", error);
             alert("Error creating room, try again with another room name.")
-            // Handle errors
         })
     });
 

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -29,7 +29,16 @@
                     <label for="form-room-description">Room description</label>
                     <input type="text" id="form-room-description" class="form-control" placeholder="Room description here...">
                 </div>
-                <button id="form-room-submit" class="btn btn-warning" type="submit">Create Room</button>
+                <div class="form-group mt-2">
+                    <label>Draw Mode</label>
+                    <div class="btn-group ms-2" role="group">
+                        <input type="radio" class="btn-check" name="drawMode" id="draw-mode-manual" value="MANUAL" checked>
+                        <label class="btn btn-outline-primary" for="draw-mode-manual">Manual</label>
+                        <input type="radio" class="btn-check" name="drawMode" id="draw-mode-automatic" value="AUTOMATIC">
+                        <label class="btn btn-outline-primary" for="draw-mode-automatic">Automatic</label>
+                    </div>
+                </div>
+                <button id="form-room-submit" class="btn btn-warning mt-2" type="submit">Create Room</button>
             </form>
         </div>
     </section>
@@ -172,6 +181,15 @@
             <button class="btn btn-primary" id="btn-confirmar-numero" disabled="true" onclick="addNumber()">Confirm</button>
 
             <h1 id="last-number"></h1>
+        </div>
+        <div class="col-md-12" id="GM-interface-auto" style="display:none">
+            <h1>Game Master interface <span class="badge bg-success">Automatic</span></h1>
+            <h1 id="inviteCodeAuto"></h1>
+            <br>
+            <button class="btn btn-lg btn-success" id="btn-draw-random" onclick="drawRandomNumber()">Draw Number</button>
+            <br><br>
+            <h1 id="last-number-auto"></h1>
+            <h2 id="all-drawn-numbers-auto"></h2>
         </div>
     </div>
 </div>

--- a/src/test/java/com/yanajiki/application/bingoapp/api/RoomControllerIntegrationTest.java
+++ b/src/test/java/com/yanajiki/application/bingoapp/api/RoomControllerIntegrationTest.java
@@ -6,6 +6,8 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -46,7 +48,7 @@ class RoomControllerIntegrationTest {
 	// ─── POST /api/v1/room ──────────────────────────────────────────────────────
 
 	/**
-	 * A valid creation request returns HTTP 200 with a populated sessionCode and creatorHash.
+	 * A valid creation request without explicit drawMode returns HTTP 200 with drawMode defaulting to MANUAL.
 	 */
 	@Test
 	void shouldCreateRoomSuccessfully() {
@@ -68,7 +70,32 @@ class RoomControllerIntegrationTest {
 			.body("description", equalTo("Weekly bingo session"))
 			.body("sessionCode", notNullValue())
 			.body("sessionCode", hasLength(6))
-			.body("creatorHash", notNullValue());
+			.body("creatorHash", notNullValue())
+			.body("drawMode", equalTo("MANUAL"));
+	}
+
+	/**
+	 * A creation request with explicit AUTOMATIC drawMode returns HTTP 200 with drawMode set to AUTOMATIC.
+	 */
+	@Test
+	void shouldCreateRoomWithAutomaticDrawMode() {
+		String requestBody = """
+			{
+				"name": "Auto Draw Night",
+				"description": "Server picks the numbers",
+				"drawMode": "AUTOMATIC"
+			}
+			""";
+
+		given()
+			.contentType(ContentType.JSON)
+			.body(requestBody)
+		.when()
+			.post("/api/v1/room")
+		.then()
+			.statusCode(200)
+			.body("name", equalTo("Auto Draw Night"))
+			.body("drawMode", equalTo("AUTOMATIC"));
 	}
 
 	/**
@@ -302,5 +329,137 @@ class RoomControllerIntegrationTest {
 			.statusCode(404)
 			.body("status", equalTo(404))
 			.body("message", notNullValue());
+	}
+
+	// ─── Draw Mode ──────────────────────────────────────────────────────────────
+
+	/**
+	 * Integration tests verifying automatic draw mode behaviour at the API level.
+	 * <p>
+	 * Covers room creation with {@code AUTOMATIC} mode, the default {@code MANUAL} fallback,
+	 * and that {@code drawMode} is returned in both creator and player views of GET room.
+	 * </p>
+	 */
+	@Nested
+	@DisplayName("Automatic Draw Mode")
+	class AutomaticDrawMode {
+
+		/**
+		 * A creation request that explicitly sets {@code drawMode} to {@code AUTOMATIC}
+		 * returns HTTP 200 and the response contains {@code drawMode: "AUTOMATIC"}.
+		 */
+		@Test
+		@DisplayName("should create room with AUTOMATIC draw mode")
+		void shouldCreateRoomWithAutomaticDrawMode() {
+			given()
+				.contentType(ContentType.JSON)
+				.body("""
+					{
+						"name": "Auto Draw Room",
+						"description": "Server picks the numbers",
+						"drawMode": "AUTOMATIC"
+					}
+					""")
+			.when()
+				.post("/api/v1/room")
+			.then()
+				.statusCode(200)
+				.body("name", equalTo("Auto Draw Room"))
+				.body("drawMode", equalTo("AUTOMATIC"));
+		}
+
+		/**
+		 * A creation request that omits {@code drawMode} returns HTTP 200 and
+		 * the response contains {@code drawMode: "MANUAL"} as the default.
+		 */
+		@Test
+		@DisplayName("should default to MANUAL draw mode when not specified")
+		void shouldDefaultToManualDrawMode() {
+			given()
+				.contentType(ContentType.JSON)
+				.body("""
+					{
+						"name": "Default Mode Room"
+					}
+					""")
+			.when()
+				.post("/api/v1/room")
+			.then()
+				.statusCode(200)
+				.body("name", equalTo("Default Mode Room"))
+				.body("drawMode", equalTo("MANUAL"));
+		}
+
+		/**
+		 * After creating a room with {@code AUTOMATIC} draw mode, a GET request
+		 * authenticated with {@code X-Creator-Hash} returns {@code drawMode: "AUTOMATIC"}
+		 * in the creator view.
+		 */
+		@Test
+		@DisplayName("should return drawMode in GET room response for creator")
+		void shouldReturnDrawModeInCreatorView() {
+			// Arrange: create room with AUTOMATIC mode and capture credentials
+			var createResponse = given()
+				.contentType(ContentType.JSON)
+				.body("""
+					{
+						"name": "Creator View Auto Room",
+						"drawMode": "AUTOMATIC"
+					}
+					""")
+			.when()
+				.post("/api/v1/room")
+			.then()
+				.statusCode(200)
+				.extract()
+				.response();
+
+			String sessionCode = createResponse.path("sessionCode");
+			String creatorHash = createResponse.path("creatorHash");
+
+			// Act & Assert: GET with creator hash returns AUTOMATIC drawMode
+			given()
+				.header("X-Creator-Hash", creatorHash)
+			.when()
+				.get("/api/v1/room/{sessionCode}", sessionCode)
+			.then()
+				.statusCode(200)
+				.body("drawMode", equalTo("AUTOMATIC"))
+				.body("creatorHash", equalTo(creatorHash));
+		}
+
+		/**
+		 * After creating a room with {@code AUTOMATIC} draw mode, a GET request
+		 * without {@code X-Creator-Hash} returns {@code drawMode: "AUTOMATIC"}
+		 * in the player view.
+		 */
+		@Test
+		@DisplayName("should return drawMode in GET room response for player")
+		void shouldReturnDrawModeInPlayerView() {
+			// Arrange: create room with AUTOMATIC mode and capture session code
+			String sessionCode = given()
+				.contentType(ContentType.JSON)
+				.body("""
+					{
+						"name": "Player View Auto Room",
+						"drawMode": "AUTOMATIC"
+					}
+					""")
+			.when()
+				.post("/api/v1/room")
+			.then()
+				.statusCode(200)
+				.extract()
+				.path("sessionCode");
+
+			// Act & Assert: GET without creator hash returns AUTOMATIC drawMode and no creatorHash
+			given()
+			.when()
+				.get("/api/v1/room/{sessionCode}", sessionCode)
+			.then()
+				.statusCode(200)
+				.body("drawMode", equalTo("AUTOMATIC"))
+				.body("$", not(hasKey("creatorHash")));
+		}
 	}
 }

--- a/src/test/java/com/yanajiki/application/bingoapp/database/RoomEntityTest.java
+++ b/src/test/java/com/yanajiki/application/bingoapp/database/RoomEntityTest.java
@@ -1,5 +1,6 @@
 package com.yanajiki.application.bingoapp.database;
 
+import com.yanajiki.application.bingoapp.game.DrawMode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -100,6 +101,47 @@ class RoomEntityTest {
 
 			// then — collision probability is ~1/36^6 ≈ 1 in 2 billion
 			assertThat(first.getSessionCode()).isNotEqualTo(second.getSessionCode());
+		}
+
+		/**
+		 * When no draw mode is supplied, the factory method must default to {@link DrawMode#MANUAL}.
+		 */
+		@Test
+		@DisplayName("defaults drawMode to MANUAL when not specified")
+		void defaultsDrawModeToManual() {
+			// when
+			RoomEntity entity = RoomEntity.createEntityObject("Manual Room", "desc");
+
+			// then
+			assertThat(entity.getDrawMode()).isEqualTo(DrawMode.MANUAL);
+		}
+
+		/**
+		 * When {@link DrawMode#AUTOMATIC} is explicitly provided, the factory method must
+		 * store it on the entity.
+		 */
+		@Test
+		@DisplayName("sets drawMode to AUTOMATIC when explicitly provided")
+		void setsDrawModeToAutomatic() {
+			// when
+			RoomEntity entity = RoomEntity.createEntityObject("Auto Room", "desc", DrawMode.AUTOMATIC);
+
+			// then
+			assertThat(entity.getDrawMode()).isEqualTo(DrawMode.AUTOMATIC);
+		}
+
+		/**
+		 * Passing {@link DrawMode#MANUAL} explicitly to the three-argument factory method
+		 * must yield the same result as the two-argument default.
+		 */
+		@Test
+		@DisplayName("sets drawMode to MANUAL when explicitly provided")
+		void setsDrawModeToManualExplicitly() {
+			// when
+			RoomEntity entity = RoomEntity.createEntityObject("Explicit Manual Room", "desc", DrawMode.MANUAL);
+
+			// then
+			assertThat(entity.getDrawMode()).isEqualTo(DrawMode.MANUAL);
 		}
 	}
 

--- a/src/test/java/com/yanajiki/application/bingoapp/service/RoomServiceTest.java
+++ b/src/test/java/com/yanajiki/application/bingoapp/service/RoomServiceTest.java
@@ -6,6 +6,7 @@ import com.yanajiki.application.bingoapp.database.RoomEntity;
 import com.yanajiki.application.bingoapp.database.RoomRepository;
 import com.yanajiki.application.bingoapp.exception.ConflictException;
 import com.yanajiki.application.bingoapp.exception.RoomNotFoundException;
+import com.yanajiki.application.bingoapp.game.DrawMode;
 import com.yanajiki.application.bingoapp.game.NumberLabelMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -50,12 +51,22 @@ class RoomServiceTest {
 	// ─── Helpers ─────────────────────────────────────────────────────────────────
 
 	/**
-	 * Builds a {@link CreateRoomForm} with the given name and description.
+	 * Builds a {@link CreateRoomForm} with the given name and description,
+	 * leaving {@code drawMode} null (service defaults to MANUAL).
 	 */
 	private CreateRoomForm buildForm(String name, String description) {
 		CreateRoomForm form = new CreateRoomForm();
 		form.setName(name);
 		form.setDescription(description);
+		return form;
+	}
+
+	/**
+	 * Builds a {@link CreateRoomForm} with the given name, description, and explicit draw mode.
+	 */
+	private CreateRoomForm buildForm(String name, String description, DrawMode drawMode) {
+		CreateRoomForm form = buildForm(name, description);
+		form.setDrawMode(drawMode);
 		return form;
 	}
 
@@ -76,10 +87,10 @@ class RoomServiceTest {
 
 		/**
 		 * A valid creation form with a unique name should persist the entity and return a creator-view DTO
-		 * that includes the {@code creatorHash} and both drawn fields (empty).
+		 * that includes the {@code creatorHash}, both drawn fields (empty), and {@code drawMode} defaulting to MANUAL.
 		 */
 		@Test
-		@DisplayName("success — saves entity and returns creator DTO with creatorHash")
+		@DisplayName("success — saves entity and returns creator DTO with creatorHash and MANUAL drawMode by default")
 		void success_savesEntityAndReturnsCreatorDto() {
 			// given
 			CreateRoomForm form = buildForm("Friday Night Bingo", "Weekly game");
@@ -99,8 +110,31 @@ class RoomServiceTest {
 			assertThat(result.creatorHash()).isNotBlank();
 			assertThat(result.drawnNumbers()).isEmpty();
 			assertThat(result.drawnLabels()).isEmpty();
+			assertThat(result.drawMode()).isEqualTo(DrawMode.MANUAL);
 
 			verify(repository).findByName("Friday Night Bingo");
+			verify(repository).save(any(RoomEntity.class));
+		}
+
+		/**
+		 * When {@code drawMode} is explicitly set to AUTOMATIC in the form, the returned DTO
+		 * must reflect AUTOMATIC — not the default MANUAL.
+		 */
+		@Test
+		@DisplayName("success — explicit AUTOMATIC drawMode is preserved in the response")
+		void success_automaticDrawMode_isPreservedInResponse() {
+			// given
+			CreateRoomForm form = buildForm("Auto Bingo Night", "Automatic draws", DrawMode.AUTOMATIC);
+			RoomEntity saved = RoomEntity.createEntityObject("Auto Bingo Night", "Automatic draws", DrawMode.AUTOMATIC);
+
+			when(repository.findByName("Auto Bingo Night")).thenReturn(Optional.empty());
+			when(repository.save(any(RoomEntity.class))).thenReturn(saved);
+
+			// when
+			RoomDTO result = roomService.createRoom(form);
+
+			// then
+			assertThat(result.drawMode()).isEqualTo(DrawMode.AUTOMATIC);
 			verify(repository).save(any(RoomEntity.class));
 		}
 
@@ -383,6 +417,134 @@ class RoomServiceTest {
 			assertThatThrownBy(() -> roomService.drawNumber(sessionCode, creatorHash, 7))
 				.isInstanceOf(IllegalArgumentException.class)
 				.hasMessageContaining("already been drawn");
+
+			verify(repository, never()).save(any());
+		}
+
+		/**
+		 * Calling {@code drawNumber()} on an AUTOMATIC room must throw {@link IllegalArgumentException}
+		 * with a message indicating automatic draw mode is in use.
+		 */
+		@Test
+		@DisplayName("wrong mode (AUTOMATIC room) — throws IllegalArgumentException")
+		void automaticRoom_throwsIllegalArgumentException() {
+			// given
+			RoomEntity entity = RoomEntity.createEntityObject("Auto Room", null, DrawMode.AUTOMATIC);
+			String sessionCode = entity.getSessionCode();
+			String creatorHash = entity.getCreatorHash();
+
+			when(repository.findBySessionCodeAndCreatorHash(sessionCode, creatorHash))
+				.thenReturn(Optional.of(entity));
+
+			// when / then
+			assertThatThrownBy(() -> roomService.drawNumber(sessionCode, creatorHash, 10))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("This room uses automatic draw mode");
+
+			verify(repository, never()).save(any());
+		}
+	}
+
+	// ─── drawRandomNumber ────────────────────────────────────────────────────────
+
+	@Nested
+	@DisplayName("drawRandomNumber")
+	class DrawRandomNumber {
+
+		/**
+		 * Drawing a random number on an AUTOMATIC room must pick one of the remaining numbers,
+		 * persist the entity, and return the player view with the new number included.
+		 */
+		@Test
+		@DisplayName("success — picks a number from remaining pool, saves entity, returns player DTO")
+		void success_picksRemainingNumberAndReturnsPlayerDto() {
+			// given
+			RoomEntity entity = RoomEntity.createEntityObject("Auto Draw Room", null, DrawMode.AUTOMATIC);
+			String sessionCode = entity.getSessionCode();
+			String creatorHash = entity.getCreatorHash();
+
+			when(repository.findBySessionCodeAndCreatorHash(sessionCode, creatorHash))
+				.thenReturn(Optional.of(entity));
+			when(repository.save(entity)).thenReturn(entity);
+			stubStandardMapper();
+
+			// when
+			RoomDTO result = roomService.drawRandomNumber(sessionCode, creatorHash);
+
+			// then
+			assertThat(result.drawnNumbers()).hasSize(1);
+			int drawnNumber = result.drawnNumbers().get(0);
+			assertThat(drawnNumber).isBetween(1, 75);
+			assertThat(result.drawnLabels()).containsExactly("X-" + drawnNumber);
+			assertThat(result.creatorHash()).isNull();
+			verify(repository).save(entity);
+		}
+
+		/**
+		 * When all 75 numbers have already been drawn, {@code drawRandomNumber()} must throw
+		 * {@link IllegalStateException}.
+		 */
+		@Test
+		@DisplayName("all numbers drawn — throws IllegalStateException")
+		void allNumbersDrawn_throwsIllegalStateException() {
+			// given
+			RoomEntity entity = RoomEntity.createEntityObject("Full Room", null, DrawMode.AUTOMATIC);
+			for (int i = 1; i <= 75; i++) {
+				entity.addDrawnNumber(i);
+			}
+			String sessionCode = entity.getSessionCode();
+			String creatorHash = entity.getCreatorHash();
+
+			when(repository.findBySessionCodeAndCreatorHash(sessionCode, creatorHash))
+				.thenReturn(Optional.of(entity));
+			when(numberLabelMapper.getMinNumber()).thenReturn(1);
+			when(numberLabelMapper.getMaxNumber()).thenReturn(75);
+
+			// when / then
+			assertThatThrownBy(() -> roomService.drawRandomNumber(sessionCode, creatorHash))
+				.isInstanceOf(IllegalStateException.class)
+				.hasMessageContaining("All numbers have been drawn");
+
+			verify(repository, never()).save(any());
+		}
+
+		/**
+		 * Calling {@code drawRandomNumber()} on a MANUAL room must throw {@link IllegalArgumentException}
+		 * with a message indicating manual draw mode is in use.
+		 */
+		@Test
+		@DisplayName("wrong mode (MANUAL room) — throws IllegalArgumentException")
+		void manualRoom_throwsIllegalArgumentException() {
+			// given
+			RoomEntity entity = RoomEntity.createEntityObject("Manual Room", null);
+			String sessionCode = entity.getSessionCode();
+			String creatorHash = entity.getCreatorHash();
+
+			when(repository.findBySessionCodeAndCreatorHash(sessionCode, creatorHash))
+				.thenReturn(Optional.of(entity));
+
+			// when / then
+			assertThatThrownBy(() -> roomService.drawRandomNumber(sessionCode, creatorHash))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("This room uses manual draw mode");
+
+			verify(repository, never()).save(any());
+		}
+
+		/**
+		 * Calling {@code drawRandomNumber()} with an unknown session code or wrong creator hash
+		 * must throw {@link RoomNotFoundException}.
+		 */
+		@Test
+		@DisplayName("room not found — throws RoomNotFoundException")
+		void roomNotFound_throwsRoomNotFoundException() {
+			// given
+			when(repository.findBySessionCodeAndCreatorHash("GHOST4", "bad-hash"))
+				.thenReturn(Optional.empty());
+
+			// when / then
+			assertThatThrownBy(() -> roomService.drawRandomNumber("GHOST4", "bad-hash"))
+				.isInstanceOf(RoomNotFoundException.class);
 
 			verify(repository, never()).save(any());
 		}


### PR DESCRIPTION
## Summary
- Add `DrawMode` enum (`MANUAL`/`AUTOMATIC`) per room, enforced at service layer
- New `/app/draw-number` WebSocket endpoint for automatic rooms — server picks random number from remaining pool
- Frontend: draw mode selector on room creation, dedicated automatic GM interface with "Draw Number" button
- Fix player subscription handler that was crashing on `drawnNumbers` array parsing

## Test plan
- [x] Unit tests for entity, service (happy path, wrong mode, all drawn, not found)
- [x] Integration tests for room creation with both modes, GET responses
- [ ] Manual test: create automatic room, draw numbers, verify player receives broadcasts

🤖 Generated with [Claude Code](https://claude.com/claude-code)